### PR TITLE
Update beta_predict.r

### DIFF
--- a/R/betacal/R/beta_predict.r
+++ b/R/betacal/R/beta_predict.r
@@ -1,4 +1,4 @@
-beta_predict <- function(p, calib){
+beta_predict <- function(p, calib, type = c("prob", "class")){
   p <- pmax(1e-16, pmin(p, 1-1e-16))
   d <- data.frame(p)
   if (calib$parameters == "abm"){
@@ -10,5 +10,10 @@ beta_predict <- function(p, calib){
     d$lp <- log(2 * p)
     d$l1p <- log(2*(1-p))
   }
-  return(predict(calib$model, newdata=d, type="response"))
+ pred <- predict(calib$model, newdata = d, type = "response")
+  if (type == "class") {
+    return(as.integer(pred >= 0.5))
+  } else {
+    return(pred)
+  }
 }


### PR DESCRIPTION
Add 'type' parameter to beta_predict() to allow predicted class output

When we need to get the predicted classes, not only the predicted probabilities. This update adds a 'type' argument ("prob" or "class") to the beta_predict() function. It returns class labels (0 or 1) when type = "class", using a 0.5 threshold.